### PR TITLE
Indicate is the argument passed is not correct

### DIFF
--- a/activity-translations
+++ b/activity-translations
@@ -51,6 +51,12 @@ fi
 # fetch latest translations
 cd po
 wget -q https://translate.sugarlabs.org/projects/$A/
+wget_output=$(wget -q https://translate.sugarlabs.org/projects/$A/)
+if [ $? -ne 0 ]; then
+    echo  "Incorrect ProjectName, check if ProjectName is one listed on translate.sugarlabs.org"
+    exit 2
+fi
+
 for x in $(grep "/$A/translate/\"" index.html | \
 	   cut -d/ -f2 | grep -v projects); do
 


### PR DESCRIPTION
Checks if the passed argument matches the Project Name, if not then echo message and exit. 
Without this commit passing an incorrect argument leads to confusing errors for someone who hasn't looked up the script code.

Tested; works!
@chimosky Please test, review and merge into the Open PR #4